### PR TITLE
Fix default Java locations

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -22,12 +22,12 @@ def ConfigCreate():
                            '1.18 Directory': APPDATA+"\\.minecraft"
                            }
     config['Java'] = {'Arguments': "-Xms3G -Xmx3G -Xmn1G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M",
-                      '1.7 Java': USERPROFILE+"\\.lunarclient\\jre\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
-                      '1.8 Java': USERPROFILE+"\\.lunarclient\\jre\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
-                      '1.12 Java': USERPROFILE+"\\.lunarclient\\jre\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
-                      '1.16 Java': USERPROFILE+"\\.lunarclient\\jre\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
-                      '1.17 Java': USERPROFILE+"\\.lunarclient\\jre\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
-                      '1.18 Java': USERPROFILE+"\\.lunarclient\\jre\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
+                      '1.7 Java': USERPROFILE+"\\.lunarclient\\jre\\1.7\\zulu16.30.15-ca-fx-jre16.0.1-win_x64\\bin\\javaw.exe",
+                      '1.8 Java': USERPROFILE+"\\.lunarclient\\jre\\1.8\\zulu16.30.15-ca-fx-jre16.0.1-win_x64\\bin\\javaw.exe",
+                      '1.12 Java': USERPROFILE+"\\.lunarclient\\jre\\1.12\\zulu16.30.15-ca-fx-jre16.0.1-win_x64\\bin\\javaw.exe",
+                      '1.16 Java': USERPROFILE+"\\.lunarclient\\jre\\1.16\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
+                      '1.17 Java': USERPROFILE+"\\.lunarclient\\jre\\1.17\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
+                      '1.18 Java': USERPROFILE+"\\.lunarclient\\jre\\1.18\\zulu17.30.15-ca-fx-jre17.0.1-win_x64\\bin\\javaw.exe",
                       }
     config['Optimizations'] = {'LC Cosmetics' : "On"}
     with open('Options.ini', 'w') as configfile:


### PR DESCRIPTION
Lunar Client made it so they use different versions of Java (17 and 16) for different versions of Minecraft. Why? I don't know... but it broke LCLPy, so here is the fix.